### PR TITLE
Add basic React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #.idea/
 /postgres_data/
 /database-kong/
+frontend/node_modules/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,14 @@
+# HiFi UI
+
+This is a simple React-based frontend for the HiFi backend API.
+
+## Development
+
+Install dependencies and start the development server:
+
+```sh
+npm install
+npm start
+```
+
+The app expects the backend API to be available at `/api`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hifi-ui",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>HiFi UI</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,4 @@
+.App {
+  font-family: Arial, Helvetica, sans-serif;
+  padding: 20px;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+import './App.css';
+
+function App() {
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetch('/api/health')
+      .then((res) => res.json())
+      .then((data) => setMessage(data.message))
+      .catch(() => setMessage('API not reachable'));
+  }, []);
+
+  return (
+    <div className="App">
+      <h1>HiFi UI</h1>
+      <p>Backend says: {message}</p>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add starter React project in `frontend`
- ignore frontend node_modules

## Testing
- `pytest --disable-warnings` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm install` in `frontend` *(fails: 403 Forbidden, internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_686c0f5327488326843585784404b806